### PR TITLE
Next steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,137 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+## Creșterea prezenței virtuale a Unităților Administrativ Teritoriale Române (UAT)
+
+S-a creeat o bază de date cu numerele de telefon emailurile si website-urile pentru fiecare UAT.
+
+## Următorii pași
+
+ * creearea de stub-uri cu informațiile disponibile pentru fiecare UAT pe [WikipediaRO](http://ro.wikipedia.org) folosind [pywikibot](https://www.mediawiki.org/wiki/Manual:Pywikibot/pagefromfile.py)
+ * înștiințarea fiecarui UAT despre wiki stub-ul lui cu propunerea menținerii lor prin mijloace proprii sau prin delegarea unei persoane cu abilități medii de utilizare a computerului (preferabil din comunitatea lor locală) care se va ocupa de menținerea paginii de wiki.


### PR DESCRIPTION
## Creșterea prezenței virtuale a Unităților Administrativ Teritoriale Române (UAT)

S-a creeat o bază de date cu numerele de telefon emailurile si website-urile pentru fiecare UAT.
## Următorii pași
- creearea de stub-uri cu informațiile disponibile pentru fiecare UAT pe [WikipediaRO](http://ro.wikipedia.org) folosind [pywikibot](https://www.mediawiki.org/wiki/Manual:Pywikibot/pagefromfile.py)
- înștiințarea fiecarui UAT despre wiki stub-ul lui cu propunerea menținerii lor prin mijloace proprii sau prin delegarea unei persoane cu abilități medii de utilizare a computerului (preferabil din comunitatea lor locală) care se va ocupa de menținerea paginii de wiki.
